### PR TITLE
Replaced `/home/nc` with environment variable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 						</goals>
 						<configuration>
 							<sourceFile>${project.build.directory}/${project.build.finalName}.jar</sourceFile>
-							<destinationFile>/home/nc/Bitwig Studio/Extensions/browserRandomizer.bwextension</destinationFile>
+							<destinationFile>${user.home}/Bitwig Studio/Extensions/browserRandomizer.bwextension</destinationFile>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
Hello, I am a fellow Bitwig Discord user, and I mentioned that I was interested in learning from your extension. 

For this PR, I updated the hardcoded `/home/nc` path in the pom file with a general `user.home` environment variable so that others interested in compiling this project will have the extension file copied to their correct extensions path.